### PR TITLE
sv command for team name changing

### DIFF
--- a/source/g_svcmds.c
+++ b/source/g_svcmds.c
@@ -6,7 +6,7 @@
 //-----------------------------------------------------------------------------
 // $Log: g_svcmds.c,v $
 //
-// Revision 1.6 2020/01/11 23:30:00  KaniZ
+// Revision 1.16 2020/01/11 23:30:00  KaniZ
 // New server commands: "sv t1name", "sv t2name" and "sv t3name"
 // Can be used to change teamname without joining the team
 //

--- a/source/g_svcmds.c
+++ b/source/g_svcmds.c
@@ -562,10 +562,10 @@ void SVCmd_Slap_f (void)
 			user_id = 0;
 	}
 
-	for( i = 0; i < maxclients->value ; i ++ )
+	for( i = 1; i <= game.maxclients; i ++ )
 	{
-		edict_t *ent = g_edicts + i + 1;
-		if( ent->inuse && ( (user_id == i + 1) || ((! user_id) && (Q_strnicmp( ent->client->pers.netname, name, name_len ) == 0)) ) )
+		edict_t *ent = g_edicts + i;
+		if( ent->inuse && ( (user_id == i) || ((! user_id) && (Q_strnicmp( ent->client->pers.netname, name, name_len ) == 0)) ) )
 		{
 			found_victim = true;
 			if( IS_ALIVE(ent) )

--- a/source/g_svcmds.c
+++ b/source/g_svcmds.c
@@ -535,6 +535,15 @@ void SVCmd_SoftQuit_f (void)
 
 void SVCmd_Slap_f (void)
 {
+	const char *name = gi.argv(2);
+	size_t name_len = strlen(name);
+	int damage = atoi(gi.argv(3));
+	float power = (gi.argc() >= 5) ? atof(gi.argv(4)) : 100.f;
+	vec3_t slap_dir = {0.f,0.f,1.f}, slap_normal = {0.f,0.f,-1.f};
+	qboolean found_victim = false;
+	size_t i = 0;
+	int user_id = name_len ? (atoi(name) + 1) : 0;
+
 	if( gi.argc() < 3 )
 	{
 		gi.cprintf( NULL, PRINT_HIGH, "Usage: sv slap <name/id> [<damage>] [<power>]\n" );
@@ -545,15 +554,6 @@ void SVCmd_Slap_f (void)
 		gi.cprintf( NULL, PRINT_HIGH, "Can't slap yet!\n" );
 		return;
 	}
-
-	const char *name = gi.argv(2);
-	size_t name_len = strlen(name);
-	int damage = atoi(gi.argv(3));
-	float power = (gi.argc() >= 5) ? atof(gi.argv(4)) : 100.f;
-	vec3_t slap_dir = {0.f,0.f,1.f}, slap_normal = {0.f,0.f,-1.f};
-	qboolean found_victim = false;
-	size_t i = 0;
-	int user_id = name_len ? (atoi(name) + 1) : 0;
 
 	// See if we're slapping by user ID.
 	for( i = 0; i < name_len; i ++ )


### PR DESCRIPTION
This pull request adds following admin commands to set team name:

```
sv t1name <name>
sv t2name <name> 
sv t3name <name>
```

they follow the syntax of existing team score altering commands:

```
sv t1score <score>
sv t2score <score> 
sv t3score <score>
```

Currently teamname can be set only client after joining team and taking captain role of team.

These new commands are usefull f.ex remote rcon tools to set up server for match beforehand.