### PR TITLE
Set gamedir to static value 'action'

### DIFF
--- a/source/acesrc/acebot_nodes.c
+++ b/source/acesrc/acebot_nodes.c
@@ -1251,23 +1251,16 @@ void ACEND_SaveNodes()
 	char filename[60];
 	int i,j;
 	int version;
-	cvar_t	*game_dir;
 
 	version = LTK_NODEVERSION;
 
-	game_dir = gi.cvar ("game", "", 0);
-
 	//@@ change 'nav' to 'terrain' to line up with William
 #ifdef	_WIN32
-	i =  sprintf(filename, ".\\");
-	i += sprintf(filename + i, game_dir->string);
-	i += sprintf(filename + i, "\\terrain\\");
+	i =  sprintf(filename, ".\\action\\terrain\\");
 	i += sprintf(filename + i, level.mapname);
 	i += sprintf(filename + i, ".ltk");
 #else
-	strcpy(filename, "./");
-	strcat(filename, game_dir->string);
-	strcat(filename, "/terrain/");
+	strcpy(filename, "./action/terrain/");
 	strcat(filename,level.mapname);
 	strcat(filename,".ltk");
 #endif
@@ -1310,20 +1303,13 @@ void ACEND_LoadNodes(void)
 	int i,j;
 	char filename[60];
 	int version;
-	cvar_t	*game_dir;
-
-	game_dir = gi.cvar ("game", "", 0);
 
 #ifdef	_WIN32
-	i =  sprintf(filename, ".\\");
-	i += sprintf(filename + i, game_dir->string);
-	i += sprintf(filename + i, "\\terrain\\");
+	i =  sprintf(filename, ".\\action\\terrain\\");
 	i += sprintf(filename + i, level.mapname);
 	i += sprintf(filename + i, ".ltk");
 #else
-	strcpy(filename, "./");
-	strcat(filename, game_dir->string);
-	strcat(filename, "/terrain/");
+	strcpy(filename, "./action/terrain/");
 	strcat(filename,level.mapname);
 	strcat(filename,".ltk");
 #endif

--- a/source/acesrc/acebot_spawn.c
+++ b/source/acesrc/acebot_spawn.c
@@ -121,7 +121,7 @@ void ACESP_JoinTeam(edict_t *ent, int desired_team)
 void ACESP_LoadBotConfig()
 {
     FILE	*pIn;
-	cvar_t	*game_dir = NULL, *botdir = NULL;
+	cvar_t  *botdir = NULL;
 #ifdef _WIN32
 	int		i;
 #endif
@@ -133,22 +133,17 @@ void ACESP_LoadBotConfig()
 	char	*sp, *tp;
 	int		ttype;
 
-	game_dir = gi.cvar ("game", "", 0);
 	botdir = gi.cvar ("botdir", "bots", 0);
 
 	// Try to load the file for THIS level
 #ifdef	_WIN32
-	i =  sprintf(filename, ".\\");
-	i += sprintf(filename + i, game_dir->string);
-	i += sprintf(filename + i, "\\");
+	i =  sprintf(filename, ".\\action\\");
 	i += sprintf(filename + i, botdir->string);
 	i += sprintf(filename + i, "\\");
 	i += sprintf(filename + i, level.mapname);
 	i += sprintf(filename + i, ".cfg");
 #else
-	strcpy(filename, "./");
-	strcat(filename, game_dir->string);
-	strcat(filename, "/");
+	strcpy(filename, "./action/");;
 	strcat(filename, botdir->string);
 	strcat(filename, "/");
 	strcat(filename, level.mapname);
@@ -159,15 +154,11 @@ void ACESP_LoadBotConfig()
 	if((pIn = fopen(filename, "rb" )) == NULL)
 	{
 #ifdef	_WIN32
-		i =  sprintf(filename, ".\\");
-		i += sprintf(filename + i, game_dir->string);
-		i += sprintf(filename + i, "\\");
+		i =  sprintf(filename, ".\\action\\");
 		i += sprintf(filename + i, botdir->string);
 		i += sprintf(filename + i, "\\botdata.cfg");
 #else
-		strcpy(filename, "./");
-		strcat(filename, game_dir->string);
-		strcat(filename, "/");
+		strcpy(filename, "./action/");
 		strcat(filename, botdir->string);
 		strcat(filename, "/botdata.cfg");
 #endif


### PR DESCRIPTION
This should resolve https://github.com/Raptor007/aq2-tng/issues/114

If you start a game without specifying `+set game action` then the cvar is empty, and the path to save the terrain file is silently broken.

I set it to a static value as I don't think we'll ever not be `action`