### PR TITLE
2.82 updates

### DIFF
--- a/TNG-manual.txt
+++ b/TNG-manual.txt
@@ -64,6 +64,13 @@ Features
   cvote_min [#] - Minimum number of players that need to vote for a single config. 0 to ignore that.
   configlistname "configlist.ini" - filename/location of the file containing all the configs people can vote for.
 
+* Teamplay
+  Enables standard 2-team round-based teamplay.  Kill everyone on the other team to win a round.
+  teamplay [0/1] (default: "0") - setting to 1 enables teamplay, requires new map or server restart
+  sv t[i]name <string> - Where i is 1, 2 or 3, sets a team name in the absence of action.ini.  Will take effect immediately.  Example: sv t1name "Robbers"
+  sv t[i]skin <string> - Where i is 1, 2 or 3, sets a team skin in the absence of action.ini.  Will take effect on a new round of teamplay or a new map.  Example: sv t2skin "male/ctf_b"
+  sv t[i]skin_index <string> - Where i is 1, 2 or 3, sets a team skin index in the absence of action.ini.  Will take effect on a new map or server restart.  Example: sv t3skin_index "siris_i"
+
 * Tourney
   For those who want to offer a Rocket Arena style one on one server, this mode is ideal. It will let two 
   players spawn and face each other. The winner will stay for the next round and the loser will go back to 
@@ -541,6 +548,21 @@ Features
 
   Commands:
   e_enhancedSlippers [0|1] (default: "0") to remove limping from leg damage (falling and shooting), and 50% damage reduction when falling long distances
+
+* Latency Compensation
+  Antilag
+  Allows server operator to enable lag-compensation for aiming with hitscan weapons, useful for making high ping games more fair.  Optionally, the server operator can enable interpolation along with antilag for aiming directly at player models to hit them.  This has the side effect of being 'shot around corners', so the best use for this setting tends to be for matches where all players pings are very low.
+
+  Commands:
+  sv_antilag [0/1] (default: "0") - Setting to "1" enables lag compensation functionality when firing hitscan weapons.
+  sv_antilag_interp [0/1] (default: "0") - Setting to "1" enables interpolation for hitscan weapons.  Requires sv_antilag "1".
+
+* General quality of life improvements
+  sv_limp_highping [#] - server cvar, players above this ping threshold will have movement prediction disabled with leg damage to make things less jittery.  Value is set in ping ms, players with a ping value equal or higher to this value will have less jittery movement.  Default value is '70'
+
+* Client Prediction
+  limp_nopred [0/1] - client cvar, clients can set this to force on or off movement prediction when taking leg damage. Set to "0" for classic behavior, set to "1" to fix the jitter
+
 
 --------------------------------------------------------------------------------------------------------------------
 Contact Information

--- a/TNG-manual.txt
+++ b/TNG-manual.txt
@@ -1,5 +1,5 @@
 Action Quake 2: The Next Generation
-Version 2.71 (April 11, 2002)
+Version 2.82 (May 14th, 2022)
 http://www.aq2tng.barrysworld.net
 by Igor, JBravo, Slicer, Deathwatch, Freud, Elviz, Rektek
 

--- a/TNG-manual.txt
+++ b/TNG-manual.txt
@@ -342,6 +342,8 @@ Features
 
   Commands:
   dmweapon "weaponname" - Starting weapon for DM mode (dmweapon), default is "MK23 Pistol".
+  dm_choose [0/1] - allows players to choose their starting weapon in DM mode, 0 disables/1 enables
+  dm_shield [#] - Sets a time value for how long the invunerability shield in DM mode.  Value of 30 = 3 seconds, for example.
 
 * Control Characters
   Some proxies use control characters to hide the name of the user. However, it is used by several players as

--- a/change.txt
+++ b/change.txt
@@ -103,7 +103,6 @@ From 2.81
 + Added 'empty_exec' to optionally execute config with empty_rotate.  Useful to revert to default settings on servers with configvote.
 + Enhanced Stealth Slippers addition (set 'e_enhancedSlippers 1')
 + Added 'tourney_lca' server cvar to enable "Lights Camera Action" at the beginning of the round rather than silence.  Set to 0 for classic use, 1 for LCA.
-+ Added 'teamplay_set_teaminfo' server cvar for avoiding server crashes due to missing action.ini.  Set to 0 for normal behavior, set to 1 to set teamplay team names and skins to default same as CTF.
 + Added bot support.  Use 'sv addbot' to spawn them on demand, or 'botdata.cfg' to spawn them every map.
 * Bots branch no longer messes up multiplayer view models (player_state_t was not the expected size).
 - Tweaked bot aiming so they're not such ridiculous crack shots in certain circumstances.

--- a/change.txt
+++ b/change.txt
@@ -1,14 +1,8 @@
-Changes in TNG
+Changes in TNG 2.82
 
 + = new feature
 - = bug fix
 * = major bug fix
-
-From 2.82
-+ Server cvar "sv_antilag" -
-+ Crouch prediction - 
-* Missing action.ini file no longer kills the server, it will default to CTF team names and skins (blue/red/green).  The presence of action.ini will still take precedence
-+ Ability to change team names and skins during teamplay with sv t[i]team, sv t[i]skin and sv t[i]skin_index where i is the team number.
 
 From 2.81
 * 3team mode: third team can not be locked forever anymore
@@ -109,6 +103,10 @@ From 2.81
 + Added 'empty_exec' to optionally execute config with empty_rotate.  Useful to revert to default settings on servers with configvote.
 + Enhanced Stealth Slippers addition (set 'e_enhancedSlippers 1')
 + Added 'tourney_lca' server cvar to enable "Lights Camera Action" at the beginning of the round rather than silence.  Set to 0 for classic use, 1 for LCA.
++ Server cvar "sv_antilag" -
++ Crouch prediction - 
+* Missing action.ini file no longer kills the server, it will default to CTF team names and skins (blue/red/green).  The presence of action.ini will still take precedence
++ Ability to change team names and skins during teamplay with sv t[i]team, sv t[i]skin and sv t[i]skin_index where i is the team number.
 
 From 2.8
 - Radio kill count was missing for falling death

--- a/change.txt
+++ b/change.txt
@@ -103,6 +103,13 @@ From 2.81
 + Added 'empty_exec' to optionally execute config with empty_rotate.  Useful to revert to default settings on servers with configvote.
 + Enhanced Stealth Slippers addition (set 'e_enhancedSlippers 1')
 + Added 'tourney_lca' server cvar to enable "Lights Camera Action" at the beginning of the round rather than silence.  Set to 0 for classic use, 1 for LCA.
++ Added 'teamplay_set_teaminfo' server cvar for avoiding server crashes due to missing action.ini.  Set to 0 for normal behavior, set to 1 to set teamplay team names and skins to default same as CTF.
++ Added bot support.  Use 'sv addbot' to spawn them on demand, or 'botdata.cfg' to spawn them every map.
+* Bots branch no longer messes up multiplayer view models (player_state_t was not the expected size).
+- Tweaked bot aiming so they're not such ridiculous crack shots in certain circumstances.
+- Bots are no longer counted in voting, and you can kickvote bots with any number of players (minimum is ignored).
++ Added optional gender to 'botdata.cfg' parsing.
+* Bot-safe printf functions no longer parse an extra level of "%".
 
 From 2.8
 - Radio kill count was missing for falling death

--- a/change.txt
+++ b/change.txt
@@ -103,10 +103,13 @@ From 2.81
 + Added 'empty_exec' to optionally execute config with empty_rotate.  Useful to revert to default settings on servers with configvote.
 + Enhanced Stealth Slippers addition (set 'e_enhancedSlippers 1')
 + Added 'tourney_lca' server cvar to enable "Lights Camera Action" at the beginning of the round rather than silence.  Set to 0 for classic use, 1 for LCA.
-+ Server cvar "sv_antilag" -
-+ Crouch prediction - 
 * Missing action.ini file no longer kills the server, it will default to CTF team names and skins (blue/red/green).  The presence of action.ini will still take precedence
-+ Ability to change team names and skins during teamplay with sv t[i]team, sv t[i]skin and sv t[i]skin_index where i is the team number.
++ Ability to change team names and skins during teamplay with sv t[i]name, sv t[i]skin and sv t[i]skin_index where i is the team number.
++ Added server cvar "sv_antilag" enables lag-compensation for aiming with hitscan weapons, useful for making high ping games more fair. (Default 0)
++ Added server cvar "sv_antilag_interp" accounts for interpolation with antilag, can cause players to be "shot around corners" even on low ping, but you can aim straight on the model. (Default 0)
++ Added server cvar "sv_limp_highping" players above this ping threshold will have movement prediction disabled with leg damage to make things less jittery. (Default 70)
++ Added userinfo Cvar "limp_nopred" clients can set this to force on or off movement prediction when taking leg damage. Legacy behavior would be "setu limp_nopred 0". (Default is decided by sv_limp_highping)
++ Exposed standing viewheight and crouched viewheight to the engine for compatible servers/clients to take advantage for use in crouch prediction.
 
 From 2.8
 - Radio kill count was missing for falling death

--- a/change.txt
+++ b/change.txt
@@ -4,6 +4,12 @@ Changes in TNG
 - = bug fix
 * = major bug fix
 
+From 2.82
++ Server cvar "sv_antilag" -
++ Crouch prediction - 
+* Missing action.ini file no longer kills the server, it will default to CTF team names and skins (blue/red/green).  The presence of action.ini will still take precedence
++ Ability to change team names and skins during teamplay with sv t[i]team, sv t[i]skin and sv t[i]skin_index where i is the team number.
+
 From 2.81
 * 3team mode: third team can not be locked forever anymore
 - Player can not flood sounds through menu

--- a/change.txt
+++ b/change.txt
@@ -103,12 +103,6 @@ From 2.81
 + Added 'empty_exec' to optionally execute config with empty_rotate.  Useful to revert to default settings on servers with configvote.
 + Enhanced Stealth Slippers addition (set 'e_enhancedSlippers 1')
 + Added 'tourney_lca' server cvar to enable "Lights Camera Action" at the beginning of the round rather than silence.  Set to 0 for classic use, 1 for LCA.
-+ Added bot support.  Use 'sv addbot' to spawn them on demand, or 'botdata.cfg' to spawn them every map.
-* Bots branch no longer messes up multiplayer view models (player_state_t was not the expected size).
-- Tweaked bot aiming so they're not such ridiculous crack shots in certain circumstances.
-- Bots are no longer counted in voting, and you can kickvote bots with any number of players (minimum is ignored).
-+ Added optional gender to 'botdata.cfg' parsing.
-* Bot-safe printf functions no longer parse an extra level of "%".
 
 From 2.8
 - Radio kill count was missing for falling death

--- a/source/Makefile
+++ b/source/Makefile
@@ -4,7 +4,7 @@
 #
 
 PACKAGE=aq2-tng
-VERSION=2.81
+VERSION=2.82
 FILE_VERSION:=$(VERSION)
 
 ## Export env TNG_BUILD_FOR=WIN32 or TNG_BUILD_FOR=WIN64 to build 32-bit exe on 64-bit arch

--- a/source/Makefile
+++ b/source/Makefile
@@ -104,7 +104,7 @@ GAME_OBJS = \
 	g_combat.o g_func.o g_items.o g_main.o g_misc.o \
 	g_phys.o g_save.o g_spawn.o g_svcmds.o g_target.o g_trigger.o \
 	g_utils.o g_weapon.o \
-	p_client.o p_hud.o p_view.o p_weapon.o q_shared.o \
+	p_antilag.o p_client.o p_hud.o p_view.o p_weapon.o q_shared.o \
 	tng_stats.o tng_flashlight.o tng_irc.o tng_ini.o tng_balancer.o \
 	g_grapple.o a_dom.o tng_jump.o
 

--- a/source/Makefile
+++ b/source/Makefile
@@ -7,6 +7,15 @@ PACKAGE=aq2-tng
 VERSION=2.81
 FILE_VERSION:=$(VERSION)
 
+## Export env TNG_BUILD_FOR=WIN32 or TNG_BUILD_FOR=WIN64 to build 32-bit exe on 64-bit arch
+ifeq ($(TNG_BUILD_FOR),WIN32)
+    WIN32=yes
+endif
+
+ifeq ($(TNG_BUILD_FOR),WIN64)
+    WIN64=yes
+endif
+
 ifndef RELEASE
 GIT_DATE=$(shell git show -s --format='%cd' --date=short)
 ifeq ($(GIT_DATE),)
@@ -46,6 +55,12 @@ endif
 
 MACHINE=$(shell uname -m)
 SYSTEM=$(shell uname -s)
+
+# Fixes by bAron to get it compiling on max m1
+ifeq ($(TNG_BUILD_FOR),M1)
+	CC=clang
+	MACHINE=arm64e
+endif
 
 ARCH=$(MACHINE)
 

--- a/source/a_game.h
+++ b/source/a_game.h
@@ -137,6 +137,7 @@ void GetLastLoss (edict_t * self, char *buf, char team);
 // ...also the modified viewheight -FB 7/18/99
 #define CROUCHING_MAXS2                 16
 #define CROUCHING_VIEWHEIGHT		8
+#define STANDING_VIEWHEIGHT			22
 
 //a_team.c
 void MakeAllLivePlayersObservers( void );

--- a/source/a_game.h
+++ b/source/a_game.h
@@ -86,7 +86,7 @@
 
 // AQ2:TNG Deathwatch - Updated the Version variables to show TNG Stuff
 #ifndef VERSION
-#define VERSION "2.81 git"
+#define VERSION "2.82 git"
 #endif
 #define TNG_TITLE "AQ2: The Next Generation"
 // AQ2:TNG Deathwatch End

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -288,6 +288,7 @@
 #include	"tng_balancer.h"
 #include	"tng_jump.h"
 #include	"g_grapple.h"
+#include	"p_antilag.h"
 #define		getEnt(entnum)	(edict_t *)((char *)globals.edicts + (globals.edict_size * entnum))	//AQ:TNG Slicer - This was missing
 #define		GAMEVERSION			"action"	// the "gameversion" client command will print this plus compile date
 
@@ -1710,6 +1711,8 @@ struct gclient_s
 	int			push_timeout;	// timeout for how long an attacker will get fall death credit
 
 	int			jumping;
+
+	antilag_t	antilag_state;
 
 	// Number of teammate woundings this game and a "before attack" tracker
 	int			team_wounds_before;

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -1115,6 +1115,13 @@ extern cvar_t *e_enhancedSlippers;
 
 extern cvar_t *sv_limp_highping;
 
+extern cvar_t *teamplay_set_teaminfo;
+extern cvar_t *teamplay_team_1_name;
+extern cvar_t *teamplay_team_2_name;
+extern cvar_t *teamplay_team_1_skin;
+extern cvar_t *teamplay_team_2_skin;
+extern cvar_t *teamplay_team_1_skin_index;
+extern cvar_t *teamplay_team_2_skin_index;
 
 #define world   (&g_edicts[0])
 

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -1115,14 +1115,6 @@ extern cvar_t *e_enhancedSlippers;
 
 extern cvar_t *sv_limp_highping;
 
-extern cvar_t *teamplay_set_teaminfo;
-extern cvar_t *teamplay_team_1_name;
-extern cvar_t *teamplay_team_2_name;
-extern cvar_t *teamplay_team_1_skin;
-extern cvar_t *teamplay_team_2_skin;
-extern cvar_t *teamplay_team_1_skin_index;
-extern cvar_t *teamplay_team_2_skin_index;
-
 #define world   (&g_edicts[0])
 
 // item spawnflags

--- a/source/g_main.c
+++ b/source/g_main.c
@@ -470,6 +470,13 @@ cvar_t *e_enhancedSlippers;
 
 cvar_t *sv_limp_highping;
 
+cvar_t *teamplay_set_teaminfo;
+cvar_t *teamplay_team_1_name;
+cvar_t *teamplay_team_2_name;
+cvar_t *teamplay_team_1_skin;
+cvar_t *teamplay_team_2_skin;
+cvar_t *teamplay_team_1_skin_index;
+cvar_t *teamplay_team_2_skin_index;
 
 void SpawnEntities (char *mapname, char *entities, char *spawnpoint);
 void ClientThink (edict_t * ent, usercmd_t * cmd);

--- a/source/g_main.c
+++ b/source/g_main.c
@@ -470,14 +470,6 @@ cvar_t *e_enhancedSlippers;
 
 cvar_t *sv_limp_highping;
 
-cvar_t *teamplay_set_teaminfo;
-cvar_t *teamplay_team_1_name;
-cvar_t *teamplay_team_2_name;
-cvar_t *teamplay_team_1_skin;
-cvar_t *teamplay_team_2_skin;
-cvar_t *teamplay_team_1_skin_index;
-cvar_t *teamplay_team_2_skin_index;
-
 void SpawnEntities (char *mapname, char *entities, char *spawnpoint);
 void ClientThink (edict_t * ent, usercmd_t * cmd);
 qboolean ClientConnect (edict_t * ent, char *userinfo);

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -546,11 +546,6 @@ void InitGame( void )
 
 	teamplay_set_teaminfo = gi.cvar( "teamplay_set_teaminfo", "0", CVAR_LATCH);
 
-	teamplay_team_1_skin = gi.cvar( "teamplay_team_1_skin", "male/ctf_r", CVAR_LATCH);
-	teamplay_team_2_skin = gi.cvar( "teamplay_team_2_skin", "male/ctf_b", CVAR_LATCH);
-	teamplay_team_1_skin_index = gi.cvar( "teamplay_team_1_skin_index", "i_ctf1", CVAR_LATCH);
-	teamplay_team_2_skin_index = gi.cvar( "teamplay_team_2_skin_index", "i_ctf2", CVAR_LATCH);
-
 	// BEGIN AQ2 ETE
 	e_enhancedSlippers = gi.cvar( "e_enhancedSlippers", "0", 0);
 	// END AQ2 ETE

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -551,18 +551,8 @@ void InitGame( void )
 	sv_antilag = gi.cvar("sv_antilag", "0", CVAR_SERVERINFO);
 	sv_limp_highping = gi.cvar("sv_limp_highping", "70", CVAR_SERVERINFO);
 
-#ifndef NO_BOTS
-	// bots
-	ltk_jumpy = gi.cvar( "ltk_jumpy", "1", CVAR_SERVERINFO );
-	ltk_skill = gi.cvar( "ltk_skill", "5", 0 );
-	ltk_showpath = gi.cvar( "ltk_showpath", "0", 0 );
-	ltk_chat = gi.cvar( "ltk_chat", "1", 0 );
-	ltk_routing = gi.cvar( "ltk_routing", "0", 0 );
-#endif
-
 	// items
 	InitItems();
-
 
 	// initialize all clients for this game
 	game.maxclients = (int)maxclients->value;

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -544,8 +544,6 @@ void InitGame( void )
 
 	use_mvd2 = gi.cvar( "use_mvd2", "0", 0 );	// JBravo: q2pro MVD2 recording. 0 = off, 1 = on
 
-	teamplay_set_teaminfo = gi.cvar( "teamplay_set_teaminfo", "0", CVAR_LATCH);
-
 	// BEGIN AQ2 ETE
 	e_enhancedSlippers = gi.cvar( "e_enhancedSlippers", "0", 0);
 	// END AQ2 ETE

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -544,10 +544,28 @@ void InitGame( void )
 
 	use_mvd2 = gi.cvar( "use_mvd2", "0", 0 );	// JBravo: q2pro MVD2 recording. 0 = off, 1 = on
 
-	e_enhancedSlippers = gi.cvar( "e_enhancedSlippers", "0", 0); // darksaint: AQ2 ETE
+	teamplay_set_teaminfo = gi.cvar( "teamplay_set_teaminfo", "0", CVAR_LATCH);
+
+	teamplay_team_1_skin = gi.cvar( "teamplay_team_1_skin", "male/ctf_r", CVAR_LATCH);
+	teamplay_team_2_skin = gi.cvar( "teamplay_team_2_skin", "male/ctf_b", CVAR_LATCH);
+	teamplay_team_1_skin_index = gi.cvar( "teamplay_team_1_skin_index", "i_ctf1", CVAR_LATCH);
+	teamplay_team_2_skin_index = gi.cvar( "teamplay_team_2_skin_index", "i_ctf2", CVAR_LATCH);
+
+	// BEGIN AQ2 ETE
+	e_enhancedSlippers = gi.cvar( "e_enhancedSlippers", "0", 0);
+	// END AQ2 ETE
 
 	sv_antilag = gi.cvar("sv_antilag", "0", CVAR_SERVERINFO);
 	sv_limp_highping = gi.cvar("sv_limp_highping", "70", CVAR_SERVERINFO);
+
+#ifndef NO_BOTS
+	// bots
+	ltk_jumpy = gi.cvar( "ltk_jumpy", "1", CVAR_SERVERINFO );
+	ltk_skill = gi.cvar( "ltk_skill", "5", 0 );
+	ltk_showpath = gi.cvar( "ltk_showpath", "0", 0 );
+	ltk_chat = gi.cvar( "ltk_chat", "1", 0 );
+	ltk_routing = gi.cvar( "ltk_routing", "0", 0 );
+#endif
 
 	// items
 	InitItems();

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -543,6 +543,8 @@ void InitGame( void )
 
 	e_enhancedSlippers = gi.cvar( "e_enhancedSlippers", "0", 0); // darksaint: AQ2 ETE
 
+	sv_antilag = gi.cvar("sv_antilag", "0", CVAR_SERVERINFO);
+
 	// items
 	InitItems();
 

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -544,6 +544,7 @@ void InitGame( void )
 	e_enhancedSlippers = gi.cvar( "e_enhancedSlippers", "0", 0); // darksaint: AQ2 ETE
 
 	sv_antilag = gi.cvar("sv_antilag", "0", CVAR_SERVERINFO);
+	sv_antilag_interp = gi.cvar("sv_antilag_interp", "0", CVAR_SERVERINFO);
 	sv_limp_highping = gi.cvar("sv_limp_highping", "70", CVAR_SERVERINFO);
 
 	// items

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -617,6 +617,9 @@ void InitGame( void )
 #endif
 
 	gi.cvar_forceset("g_features", va("%d", G_FEATURES));
+	gi.cvar_forceset("g_view_predict", "1");
+	gi.cvar_forceset("g_view_high", va("%d", STANDING_VIEWHEIGHT));
+	gi.cvar_forceset("g_view_low", va("%d", CROUCHING_VIEWHEIGHT));
 }
 
 //=========================================================

--- a/source/g_spawn.c
+++ b/source/g_spawn.c
@@ -1043,15 +1043,6 @@ void SpawnEntities (char *mapname, char *entities, char *spawnpoint)
 	else if (teamplay->value)
 	{
 		gameSettings |= (GS_ROUNDBASED | GS_WEAPONCHOOSE);
-
-		if (teamplay_set_teaminfo->value == 1) {
-			strcpy(teams[TEAM1].name, "RED");
-			strcpy(teams[TEAM2].name, "BLUE");
-			strcpy(teams[TEAM1].skin, "male/ctf_r");
-			strcpy(teams[TEAM2].skin, "male/ctf_b");
-			strcpy(teams[TEAM1].skin_index, "i_ctf1");
-			strcpy(teams[TEAM2].skin_index, "i_ctf2");
-		}
 	}
 	else { //Its deathmatch
 		gameSettings |= GS_DEATHMATCH;
@@ -1566,9 +1557,20 @@ void SP_worldspawn (edict_t * ent)
 
 		for(i = TEAM1; i <= teamCount; i++)
 		{
-			if (teams[i].skin_index[0] == 0 && !teamplay_set_teaminfo->value) {
-				gi.dprintf("No skin was specified for team %i in config file or teamplay_set_teaminfo. Exiting.\n", i);
-				exit(1);
+			if (teams[i].skin_index[0] == 0) {
+				// If the action.ini file isn't found, set default skins rather than kill the server
+				gi.dprintf("WARNING: No skin was specified for team %i in config file, server either could not find it or is does not exist.\n", i);
+				gi.dprintf("Setting default team names, skins and skin indexes.\n", i);
+				strcpy(teams[TEAM1].name, "RED");
+				strcpy(teams[TEAM2].name, "BLUE");
+				strcpy(teams[TEAM3].name, "GREEN");
+				strcpy(teams[TEAM1].skin, "male/ctf_r");
+				strcpy(teams[TEAM2].skin, "male/ctf_b");
+				strcpy(teams[TEAM3].skin, "male/ctf_g");
+				strcpy(teams[TEAM1].skin_index, "ctf_r_i");
+				strcpy(teams[TEAM2].skin_index, "ctf_b_i");
+				strcpy(teams[TEAM3].skin_index, "ctf_g_i");
+				//exit(1);
 			}
 			level.pic_teamskin[i] = gi.imageindex(teams[i].skin_index);
 		}

--- a/source/g_spawn.c
+++ b/source/g_spawn.c
@@ -1069,18 +1069,6 @@ void SpawnEntities (char *mapname, char *entities, char *spawnpoint)
 
 	gi.FreeTags(TAG_LEVEL);
 
-#ifndef NO_BOTS
-	// Disconnect bots before we wipe entity data and lose track of is_bot.
-	for (i = 0, ent = &g_edicts[1]; i < game.maxclients; i++, ent++)
-	{
-		if( ent->is_bot )
-		{
-			client = &game.clients[i];
-			client->pers.connected = false;
-		}
-	}
-#endif
-
 	memset(&level, 0, sizeof (level));
 	memset(g_edicts, 0, game.maxentities * sizeof (g_edicts[0]));
 
@@ -1197,13 +1185,6 @@ void SpawnEntities (char *mapname, char *entities, char *spawnpoint)
 	G_LoadLocations();
 
 	UnBan_TeamKillers();
-
-#ifndef NO_BOTS
-	// Reload nodes and any persistent bots.
-	ACEND_InitNodes();
-	ACEND_LoadNodes();
-	ACESP_LoadBotConfig();
-#endif
 }
 
 
@@ -1438,10 +1419,6 @@ void G_UpdatePlayerStatusbar( edict_t * ent, int force )
 		playerStatusbar = level.spec_statusbar;
 	}
 
-#ifndef NO_BOTS
-	if( ent->is_bot )
-		return;
-#endif
 	gi.WriteByte( svc_configstring );
 	gi.WriteShort( CS_STATUSBAR );
 	gi.WriteString( playerStatusbar );

--- a/source/g_spawn.c
+++ b/source/g_spawn.c
@@ -1566,7 +1566,7 @@ void SP_worldspawn (edict_t * ent)
 
 		for(i = TEAM1; i <= teamCount; i++)
 		{
-			if (teams[i].skin_index[0] == 0) {
+			if (teams[i].skin_index[0] == 0 && !teamplay_set_teaminfo->value) {
 				gi.dprintf("No skin was specified for team %i in config file or teamplay_set_teaminfo. Exiting.\n", i);
 				exit(1);
 			}

--- a/source/g_svcmds.c
+++ b/source/g_svcmds.c
@@ -705,65 +705,6 @@ void ServerCommand (void)
 		SVCmd_Slap_f ();
 	else if (Q_stricmp(cmd, "scramble") == 0)
 		SVCmd_Scramble_f();
-#ifndef NO_BOTS
-	else if(Q_stricmp (cmd, "botdebug") == 0)
-	{
- 		if (strcmp(gi.argv(2),"on")==0)
-		{
-			gi.bprintf (PRINT_MEDIUM, "BOT: Debug Mode On\n");
-			debug_mode = true;
-		}
-		else
-		{
-			gi.bprintf (PRINT_MEDIUM, "BOT: Debug Mode Off\n");
-			debug_mode = false;
-		}
-	}
-	//RiEvEr - new node visibility method
-	else if(Q_stricmp (cmd, "shownodes") == 0)
-	{
- 		if (strcmp(gi.argv(2),"on")==0)
-		{
-			gi.bprintf (PRINT_MEDIUM, "BOT: ShowNodes On\n");
-			shownodes_mode = true;
-		}
-		else
-		{
-			gi.bprintf (PRINT_MEDIUM, "BOT: ShowNodes Off\n");
-			shownodes_mode = false;
-		}
-	}
-	else if (Q_stricmp (cmd, "addbot") == 0)
-	{
-		if(teamplay->value) // team, name, skin (ignored)
-			ACESP_SpawnBot (gi.argv(2), gi.argv(3), gi.argv(4), NULL);
-		else // name, skin
-			ACESP_SpawnBot (NULL, gi.argv(2), gi.argv(3), NULL);
-	}
-	else if (Q_stricmp (cmd, "addbots") == 0)
-	{
-		if( gi.argc() >= 3 )
-		{
-			int count = atoi(gi.argv(2)), i = 0;
-			for( i = 0; i < count; i ++ )
-				ACESP_SpawnBot( gi.argv(3), NULL, NULL, NULL );
-		}
-		else
-			gi.cprintf( NULL, PRINT_HIGH, "Usage: sv addbots <count> [<team>]\n" );
-	}
-	// removebot
-	else if(Q_stricmp (cmd, "removebot") == 0)
-		ACESP_RemoveBot(gi.argv(2));
-	// Node saving
-	else if(Q_stricmp (cmd, "savenodes") == 0)
-		ACEND_SaveNodes();
-	// Clear all node data.
-	else if(Q_stricmp (cmd, "initnodes") == 0)
-		ACEND_InitNodes();
-	// Generate map entity nodes (items/doors/etc) and load saved nodes; you should probably "initnodes" first.
-	else if(Q_stricmp (cmd, "loadnodes") == 0)
-		ACEND_LoadNodes();
-#endif
 	else
 		gi.cprintf (NULL, PRINT_HIGH, "Unknown server command \"%s\"\n", cmd);
 }

--- a/source/g_svcmds.c
+++ b/source/g_svcmds.c
@@ -527,6 +527,44 @@ void SVCmd_SetTeamName_f( int team )
 	gi.bprintf( PRINT_HIGH, "Team %i name set to %s by console.\n", team, teams[team].name );
 }
 
+void SVCmd_SetTeamSkin_f( int team )
+{
+	if( ! teamplay->value )
+	{
+		gi.cprintf( NULL, PRINT_HIGH, "Team skins can only be set for teamplay.\n" );
+		return;
+	}
+
+	if( gi.argc() < 3 )
+	{
+		gi.cprintf( NULL, PRINT_HIGH, "Usage: sv %s <name>\n", gi.argv(1) );
+		return;
+	}
+
+	strcpy(teams[team].skin, gi.argv(2));
+
+	gi.bprintf( PRINT_HIGH, "Team %i skin set to %s by console.\n", team, teams[team].name );
+}
+
+void SVCmd_SetTeamSkin_Index_f( int team )
+{
+	if( ! teamplay->value )
+	{
+		gi.cprintf( NULL, PRINT_HIGH, "Team skin indexes can only be set for teamplay.\n" );
+		return;
+	}
+
+	if( gi.argc() < 3 )
+	{
+		gi.cprintf( NULL, PRINT_HIGH, "Usage: sv %s <name>\n", gi.argv(1) );
+		return;
+	}
+
+	strcpy(teams[team].skin_index, gi.argv(2));
+
+	gi.bprintf( PRINT_HIGH, "Team %i skin set to %s by console.\n", team, teams[team].name );
+}
+
 void SVCmd_SoftQuit_f (void)
 {
 	gi.bprintf(PRINT_HIGH, "The server will exit after this map\n");
@@ -649,12 +687,83 @@ void ServerCommand (void)
 		SVCmd_SetTeamName_f( 2 );
 	else if (Q_stricmp (cmd, "t3name") == 0)
 		SVCmd_SetTeamName_f( 3 );
+	else if (Q_stricmp (cmd, "t1skin") == 0)
+		SVCmd_SetTeamSkin_f( 1 );
+	else if (Q_stricmp (cmd, "t2skin") == 0)
+		SVCmd_SetTeamSkin_f( 2 );
+	else if (Q_stricmp (cmd, "t3skin") == 0)
+		SVCmd_SetTeamSkin_f( 3 );
+	else if (Q_stricmp (cmd, "t1skin_index") == 0)
+		SVCmd_SetTeamSkin_Index_f( 1 );
+	else if (Q_stricmp (cmd, "t2skin_index") == 0)
+		SVCmd_SetTeamSkin_Index_f( 2 );
+	else if (Q_stricmp (cmd, "t3skin_index") == 0)
+		SVCmd_SetTeamSkin_Index_f( 3 );
 	else if (Q_stricmp (cmd, "softquit") == 0)
 		SVCmd_SoftQuit_f ();
 	else if (Q_stricmp (cmd, "slap") == 0)
 		SVCmd_Slap_f ();
 	else if (Q_stricmp(cmd, "scramble") == 0)
 		SVCmd_Scramble_f();
+#ifndef NO_BOTS
+	else if(Q_stricmp (cmd, "botdebug") == 0)
+	{
+ 		if (strcmp(gi.argv(2),"on")==0)
+		{
+			gi.bprintf (PRINT_MEDIUM, "BOT: Debug Mode On\n");
+			debug_mode = true;
+		}
+		else
+		{
+			gi.bprintf (PRINT_MEDIUM, "BOT: Debug Mode Off\n");
+			debug_mode = false;
+		}
+	}
+	//RiEvEr - new node visibility method
+	else if(Q_stricmp (cmd, "shownodes") == 0)
+	{
+ 		if (strcmp(gi.argv(2),"on")==0)
+		{
+			gi.bprintf (PRINT_MEDIUM, "BOT: ShowNodes On\n");
+			shownodes_mode = true;
+		}
+		else
+		{
+			gi.bprintf (PRINT_MEDIUM, "BOT: ShowNodes Off\n");
+			shownodes_mode = false;
+		}
+	}
+	else if (Q_stricmp (cmd, "addbot") == 0)
+	{
+		if(teamplay->value) // team, name, skin (ignored)
+			ACESP_SpawnBot (gi.argv(2), gi.argv(3), gi.argv(4), NULL);
+		else // name, skin
+			ACESP_SpawnBot (NULL, gi.argv(2), gi.argv(3), NULL);
+	}
+	else if (Q_stricmp (cmd, "addbots") == 0)
+	{
+		if( gi.argc() >= 3 )
+		{
+			int count = atoi(gi.argv(2)), i = 0;
+			for( i = 0; i < count; i ++ )
+				ACESP_SpawnBot( gi.argv(3), NULL, NULL, NULL );
+		}
+		else
+			gi.cprintf( NULL, PRINT_HIGH, "Usage: sv addbots <count> [<team>]\n" );
+	}
+	// removebot
+	else if(Q_stricmp (cmd, "removebot") == 0)
+		ACESP_RemoveBot(gi.argv(2));
+	// Node saving
+	else if(Q_stricmp (cmd, "savenodes") == 0)
+		ACEND_SaveNodes();
+	// Clear all node data.
+	else if(Q_stricmp (cmd, "initnodes") == 0)
+		ACEND_InitNodes();
+	// Generate map entity nodes (items/doors/etc) and load saved nodes; you should probably "initnodes" first.
+	else if(Q_stricmp (cmd, "loadnodes") == 0)
+		ACEND_LoadNodes();
+#endif
 	else
 		gi.cprintf (NULL, PRINT_HIGH, "Unknown server command \"%s\"\n", cmd);
 }

--- a/source/g_svcmds.c
+++ b/source/g_svcmds.c
@@ -543,7 +543,7 @@ void SVCmd_SetTeamSkin_f( int team )
 
 	strcpy(teams[team].skin, gi.argv(2));
 
-	gi.bprintf( PRINT_HIGH, "Team %i skin set to %s by console.\n", team, teams[team].name );
+	gi.bprintf( PRINT_HIGH, "Team %i skin set to %s by console. New skin will be reflected upon next round.\n", team, teams[team].skin );
 }
 
 void SVCmd_SetTeamSkin_Index_f( int team )
@@ -562,7 +562,7 @@ void SVCmd_SetTeamSkin_Index_f( int team )
 
 	strcpy(teams[team].skin_index, gi.argv(2));
 
-	gi.bprintf( PRINT_HIGH, "Team %i skin set to %s by console.\n", team, teams[team].name );
+	gi.bprintf( PRINT_HIGH, "Team %i skin index set to %s by console. Requires a server restart or new map load.\n", team, teams[team].skin_index );
 }
 
 void SVCmd_SoftQuit_f (void)

--- a/source/g_svcmds.c
+++ b/source/g_svcmds.c
@@ -543,7 +543,7 @@ void SVCmd_SetTeamSkin_f( int team )
 
 	strcpy(teams[team].skin, gi.argv(2));
 
-	gi.bprintf( PRINT_HIGH, "Team %i skin set to %s by console. New skin will be reflected upon next round.\n", team, teams[team].skin );
+	gi.bprintf( PRINT_HIGH, "Team %i skin set to %s by console and will be reflected next round.\n", team, teams[team].skin );
 }
 
 void SVCmd_SetTeamSkin_Index_f( int team )
@@ -562,7 +562,7 @@ void SVCmd_SetTeamSkin_Index_f( int team )
 
 	strcpy(teams[team].skin_index, gi.argv(2));
 
-	gi.bprintf( PRINT_HIGH, "Team %i skin index set to %s by console. Requires a server restart or new map load.\n", team, teams[team].skin_index );
+	gi.bprintf( PRINT_HIGH, "Team %i skin index set to %s by console, requires a new map or server restart.\n", team, teams[team].skin_index );
 }
 
 void SVCmd_SoftQuit_f (void)

--- a/source/g_weapon.c
+++ b/source/g_weapon.c
@@ -261,7 +261,9 @@ pistols, rifles, etc....
 void fire_bullet(edict_t *self, vec3_t start, vec3_t aimdir, int damage, int kick, int hspread, int vspread, int mod)
 {
 	setFFState(self);
+	antilag_rewind_all(self);
 	fire_lead(self, start, aimdir, damage, kick, TE_GUNSHOT, hspread, vspread, mod);
+	antilag_unmove_all();
 }
 
 
@@ -467,14 +469,18 @@ static void fire_lead_ap(edict_t *self, vec3_t start, vec3_t aimdir, int damage,
 void fire_bullet_sparks (edict_t *self, vec3_t start, vec3_t aimdir, int damage, int kick, int hspread, int vspread, int mod)
 {
 	setFFState(self);
+	antilag_rewind_all(self);
 	fire_lead_ap(self, start, aimdir, damage, kick, TE_BULLET_SPARKS, hspread, vspread, mod);
+	antilag_unmove_all();
 }
 
 // zucc - for sniper
 void fire_bullet_sniper (edict_t *self, vec3_t start, vec3_t aimdir, int damage, int kick, int hspread, int vspread, int mod)
 {
 	setFFState (self);
+	antilag_rewind_all(self);
 	fire_lead_ap (self, start, aimdir, damage, kick, TE_GUNSHOT, hspread, vspread, mod);
+	antilag_unmove_all();
 }
 
 
@@ -546,8 +552,10 @@ void fire_shotgun(edict_t *self, vec3_t start, vec3_t aimdir, int damage, int ki
 {
 	int i;
 
+	antilag_rewind_all(self);
 	for (i = 0; i < count; i++)
 		fire_lead (self, start, aimdir, damage, kick, TE_SHOTGUN, hspread, vspread, mod);
+	antilag_unmove_all();
 }
 
 

--- a/source/p_antilag.c
+++ b/source/p_antilag.c
@@ -86,7 +86,7 @@ void antilag_rewind_all(edict_t *ent)
 			continue;
 
 		float rewind_seek = antilag_findseek(who, time_to_seek);
-		Com_Printf("rewind seek %f\n", rewind_seek);
+		//Com_Printf("rewind seek %f\n", rewind_seek);
 		if (rewind_seek < 0)
 			continue;
 
@@ -95,7 +95,7 @@ void antilag_rewind_all(edict_t *ent)
 		VectorCopy(who->mins, state->hold_mins);
 		VectorCopy(who->maxs, state->hold_maxs);
 
-		Com_Printf("seek diff %f\n", (float)state->seek - rewind_seek);
+		//Com_Printf("seek diff %f\n", (float)state->seek - rewind_seek);
 		LerpVector(state->hist_origin[((int)rewind_seek) & ANTILAG_MASK], state->hist_origin[((int)(rewind_seek+1)) & ANTILAG_MASK], rewind_seek - ((float)(int)rewind_seek), who->s.origin);
 
 		VectorCopy(state->hist_mins[(int)rewind_seek & ANTILAG_MASK], who->mins);

--- a/source/p_antilag.c
+++ b/source/p_antilag.c
@@ -1,0 +1,143 @@
+
+#include "g_local.h"
+
+cvar_t *sv_antilag;
+
+void antilag_update(edict_t *ent)
+{
+	antilag_t *state = &ent->client->antilag_state;
+
+	state->seek++;
+	state->curr_timestamp = level.time;
+
+	float time_stamp;
+	if ((int)sv_antilag->value == 2)
+		time_stamp = level.time;
+	else
+		time_stamp = level.time + FRAMETIME;
+
+	state->hist_timestamp[state->seek & ANTILAG_MASK] = time_stamp;
+	VectorCopy(ent->s.origin, state->hist_origin[state->seek & ANTILAG_MASK]);
+	VectorCopy(ent->mins, state->hist_mins[state->seek & ANTILAG_MASK]);
+	VectorCopy(ent->maxs, state->hist_maxs[state->seek & ANTILAG_MASK]);
+}
+
+
+void antilag_clear(edict_t *ent)
+{
+	memset(&ent->client->antilag_state, 0, sizeof(antilag_t));
+}
+
+
+float antilag_findseek(edict_t *ent, float time_stamp)
+{
+	antilag_t *state = &ent->client->antilag_state;
+
+	int offs = 0;
+	while (offs < ANTILAG_MAX)
+	{
+		if (state->hist_timestamp[(state->seek - offs) & ANTILAG_MASK] && state->hist_timestamp[(state->seek - offs) & ANTILAG_MASK] <= time_stamp)
+		{
+			if ((offs - 1) < 0) // never return a timestamp from the future aka erroneous crap
+				return -1;
+
+			float frac = 1;
+			float stamp_last = state->hist_timestamp[(state->seek - offs) & ANTILAG_MASK];
+			float stamp_next = state->hist_timestamp[(state->seek - (offs - 1)) & ANTILAG_MASK];
+
+			time_stamp -= stamp_last;
+			frac = time_stamp / (stamp_next - stamp_last);
+
+			return (float)(state->seek - offs) + frac;
+		}
+
+		offs++;
+	}
+
+	return -1;
+}
+
+
+void antilag_rewind_all(edict_t *ent)
+{
+	if (!sv_antilag->value)
+		return;
+
+	float time_to_seek = ent->client->antilag_state.curr_timestamp;
+	time_to_seek -= ((float)ent->client->ping) / 1000;
+	if (time_to_seek < level.time - ANTILAG_REWINDCAP)
+		time_to_seek = level.time - ANTILAG_REWINDCAP;
+
+	edict_t *who;
+	antilag_t *state;
+	for (int i = 1; i < game.maxclients; i++)
+	{
+		who = g_edicts + i;
+		if (!who->inuse)
+			continue;
+
+		state = &who->client->antilag_state;
+		state->rewound = false;
+
+		if (who == ent)
+			continue;
+
+		if (who->deadflag != DEAD_NO)
+			continue;
+
+		float rewind_seek = antilag_findseek(who, time_to_seek);
+		Com_Printf("rewind seek %f\n", rewind_seek);
+		if (rewind_seek < 0)
+			continue;
+
+		state->rewound = true;
+		VectorCopy(who->s.origin, state->hold_origin);
+		VectorCopy(who->mins, state->hold_mins);
+		VectorCopy(who->maxs, state->hold_maxs);
+
+		Com_Printf("seek diff %f\n", (float)state->seek - rewind_seek);
+		LerpVector(state->hist_origin[((int)rewind_seek) & ANTILAG_MASK], state->hist_origin[((int)(rewind_seek+1)) & ANTILAG_MASK], rewind_seek - ((float)(int)rewind_seek), who->s.origin);
+
+		VectorCopy(state->hist_mins[(int)rewind_seek & ANTILAG_MASK], who->mins);
+		VectorCopy(state->hist_maxs[(int)rewind_seek & ANTILAG_MASK], who->maxs);
+
+
+
+		gi.linkentity(who);
+	}
+}
+
+
+void antilag_unmove_all(void)
+{
+	if (!sv_antilag->value)
+		return;
+
+	edict_t *who;
+	antilag_t *state;
+	for (int i = 1; i < game.maxclients; i++)
+	{
+		who = g_edicts + i;
+		if (!who->inuse)
+			continue;
+
+		state = &who->client->antilag_state;
+
+		if (!state->rewound)
+			continue;
+
+		VectorCopy(state->hold_origin, who->s.origin);
+		VectorCopy(state->hold_mins, who->mins);
+		VectorCopy(state->hold_maxs, who->maxs);
+
+		gi.linkentity(who);
+	}
+}
+
+
+
+
+
+
+
+

--- a/source/p_antilag.c
+++ b/source/p_antilag.c
@@ -2,19 +2,18 @@
 #include "g_local.h"
 
 cvar_t *sv_antilag;
+cvar_t *sv_antilag_interp;
 
 void antilag_update(edict_t *ent)
 {
-	antilag_t *state = &ent->client->antilag_state;
+	antilag_t *state = &(ent->client->antilag_state);
 
 	state->seek++;
 	state->curr_timestamp = level.time;
 
-	float time_stamp;
-	if ((int)sv_antilag->value == 2)
-		time_stamp = level.time;
-	else
-		time_stamp = level.time + FRAMETIME;
+	float time_stamp = level.time;
+	if (sv_antilag_interp->value) // offset by 1 server frame to account for interpolation
+		time_stamp += FRAMETIME;
 
 	state->hist_timestamp[state->seek & ANTILAG_MASK] = time_stamp;
 	VectorCopy(ent->s.origin, state->hist_origin[state->seek & ANTILAG_MASK]);
@@ -31,7 +30,7 @@ void antilag_clear(edict_t *ent)
 
 float antilag_findseek(edict_t *ent, float time_stamp)
 {
-	antilag_t *state = &ent->client->antilag_state;
+	antilag_t *state = &(ent->client->antilag_state);
 
 	int offs = 0;
 	while (offs < ANTILAG_MAX)

--- a/source/p_antilag.h
+++ b/source/p_antilag.h
@@ -21,6 +21,7 @@ typedef struct antilag_s
 } antilag_t;
 
 extern cvar_t *sv_antilag;
+extern cvar_t *sv_antilag_interp;
 void antilag_update(edict_t *ent);
 void antilag_rewind_all(edict_t *ent);
 void antilag_unmove_all(void);

--- a/source/p_antilag.h
+++ b/source/p_antilag.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#define ANTILAG_MASK		63
+#define ANTILAG_MAX			64
+#define ANTILAG_REWINDCAP	0.25
+
+typedef struct antilag_s
+{
+	int		seek;
+	int		rewound;
+	float	curr_timestamp;
+
+	float	hist_timestamp[ANTILAG_MAX];
+	vec3_t	hist_origin[ANTILAG_MAX];
+	vec3_t	hist_mins[ANTILAG_MAX];
+	vec3_t	hist_maxs[ANTILAG_MAX];
+
+	vec3_t	hold_origin;
+	vec3_t	hold_mins;
+	vec3_t	hold_maxs;
+} antilag_t;
+
+extern cvar_t *sv_antilag;
+void antilag_update(edict_t *ent);
+void antilag_rewind_all(edict_t *ent);
+void antilag_unmove_all(void);
+
+
+
+

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -3159,7 +3159,8 @@ void ClientBeginServerFrame(edict_t * ent)
 
 	client = ent->client;
 
-	antilag_update(ent);
+	if (sv_antilag->value) // if sv_antilag is enabled, we want to track our player position for later reference
+		antilag_update(ent);
 
 	if (client->resp.penalty > 0 && level.realFramenum % HZ == 0)
 		client->resp.penalty--;

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -2193,9 +2193,9 @@ void ClientLegDamage(edict_t *ent)
 	// Reki: limp_nopred behavior
 	switch (ent->client->pers.limp_nopred & 255)
 	{
-		case -1:
-			break;
 		case 0:
+			break;
+		case 2:
 			if (sv_limp_highping->value <= 0)
 				break;
 			// if the 256 bit flag is set, we have to be cautious to only deactivate if ping swung significantly
@@ -2663,9 +2663,9 @@ void ClientUserinfoChanged(edict_t *ent, char *userinfo)
 	if (limp == 1)
 		client->pers.limp_nopred = 1; // client explicity wants new behavior 
 	else if (s[0] == 0)
-		client->pers.limp_nopred = 0 | (client->pers.limp_nopred & 256); // client doesn't specify, so use auto threshold
+		client->pers.limp_nopred = 2 | (client->pers.limp_nopred & 256); // client doesn't specify, so use auto threshold
 	else if (limp == 0)
-		client->pers.limp_nopred = -1; // client explicity wants old behavior
+		client->pers.limp_nopred = 0; // client explicity wants old behavior
 }
 
 /*

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -2882,6 +2882,8 @@ void ClientThink(edict_t * ent, usercmd_t * ucmd)
 
 	level.current_entity = ent;
 	client = ent->client;
+	
+	client->antilag_state.curr_timestamp += (float)ucmd->msec / 1000; // antilag needs sub-server-frame timestamps
 
 	if (level.intermission_framenum) {
 		client->ps.pmove.pm_type = PM_FREEZE;
@@ -3103,6 +3105,8 @@ void ClientBeginServerFrame(edict_t * ent)
 	FrameStartZ( ent );
 
 	client = ent->client;
+
+	antilag_update(ent);
 
 	if (client->resp.penalty > 0 && level.realFramenum % HZ == 0)
 		client->resp.penalty--;

--- a/source/q_shared.h
+++ b/source/q_shared.h
@@ -305,6 +305,10 @@ extern long Q_ftol (float f);
 #define VectorLength(v)			(sqrtf(DotProduct((v),(v))))
 #define VectorInverse(v)		((v)[0]=-(v)[0],(v)[1]=-(v)[1],(v)[2]=-(v)[2])
 #define VectorScale(in,s,out)	((out)[0]=(in)[0]*(s),(out)[1]=(in)[1]*(s),(out)[2]=(in)[2]*(s))
+#define LerpVector(a,b,c,d) \
+    ((d)[0]=(a)[0]+(c)*((b)[0]-(a)[0]), \
+     (d)[1]=(a)[1]+(c)*((b)[1]-(a)[1]), \
+     (d)[2]=(a)[2]+(c)*((b)[2]-(a)[2]))
 
 #define VectorCopyMins(a,b,c)	((c)[0]=min((a)[0],(b)[0]),(c)[0]=min((a)[1],(b)[1]),(c)[2]=min((a)[2],(b)[2]))
 #define VectorCopyMaxs(a,b,c)	((c)[0]=max((a)[0],(b)[0]),(c)[0]=max((a)[1],(b)[1]),(c)[2]=max((a)[2],(b)[2]))


### PR DESCRIPTION
I think the changes we've added recently along with the scope of changes warrants us to bump up the version to 2.82 unless you feel otherwise @Raptor007 

1. Major addition of sv_antilag by Iceman12k for server prediction, will update the change.txt with more info before I change this PR from draft status
2. Crouch prediction
3. Ability to change team names, skins and skin indexes during a match (with some limitations)
4. Server no longer crashes if action.ini is missing, will warn the operator/player that the file is missing or couldn't be loaded, and loads CTF teamnames/skins rather than killing the server