### PR TITLE
Fix segfault IRC_printf passing invalid val type

### DIFF
--- a/source/a_match.c
+++ b/source/a_match.c
@@ -304,7 +304,7 @@ void Cmd_Teamname_f(edict_t * ent)
 		strcpy( temp, "noname" );
 
 	gi.dprintf("%s (team %i) is now known as %s\n", team->name, teamNum, temp);
-	IRC_printf(IRC_T_GAME, "%n (team %i) is now known as %n", team->name, teamNum, temp);
+	IRC_printf(IRC_T_GAME, "%n (team %k) is now known as %n", team->name, teamNum, temp);
 	strcpy(team->name, temp);
 	gi.cprintf(ent, PRINT_HIGH, "New team name: %s\n", team->name);
 


### PR DESCRIPTION
IRC_printf would segfault if ircbot=1 and connected to an IRC server because it doesn't use %i (see https://github.com/Raptor007/aq2-tng/blob/master/source/tng_irc.c#L482-L491), suggested change to %k