### PR TITLE
Enhancements/bug fixes/default adjustments from AQtion

### DIFF
--- a/TNG-manual.txt
+++ b/TNG-manual.txt
@@ -581,7 +581,8 @@ Features
   limp_nopred [0/1] - client cvar, clients can set this to force on or off movement prediction when taking leg damage.
   Set to "0" for classic behavior, set to "1" to fix the jitter
 
-
+* Force Spawn items
+  g_spawn_items [0/1] - server cvar, set to "1" to allow for item/ammo/weapon spawns in games that you choose your starting weapon, for example, dm_choose, teamplay, etc.  Forced set to "0" for matchmode.  Set "0" for normal play.
 --------------------------------------------------------------------------------------------------------------------
 Contact Information
   If you wish to contact the TNG team, to report a bug, suggest a new feature, or offer JBravo your

--- a/change.txt
+++ b/change.txt
@@ -8,6 +8,7 @@ From 2.82
 + mapvote_next_limit: Value in seconds, restricts players from voting for a map at the very end of the match while still enabling mapvote_next features
 + New server cvar 'scoreboard' allows customizing fields of second scoreboard screen in team modes.
 + sv_idleremove: Value in seconds, removes player from their team if they reach this amount of total idle time. Set to 0 to disable, Teamplay modes only.
++ g_spawn_items: Value [0/1], set to 1 to allow for item/ammo/weapon spawns in games that you choose your starting weapon.  Set 0 for normal play.
 
 From 2.81
 * 3team mode: third team can not be locked forever anymore
@@ -100,7 +101,7 @@ From 2.81
 + Added 'sv_fps' support for servers that implement variable framerate.  Multiple of 10; higher values reduce lag.  Default value (10) retains old behavior.
 - Climbing down ladders no longer makes a footstep sound every server frame (it sounded awful at higher sv_fps).
 + Added 'sync_guns' for sound timing with sv_fps: 0 plays shots immediately, 1 (default) syncs when multiple are firing, 2 delays all shot sounds to 10fps.
-+ Added 'loud_guns' to make non-silenced shots heard from farther away.  Default 1 is on, set to 0 for classic sound attenuation.
++ Added 'loud_guns' to make non-silenced shots heard from farther away.  Default 0 is off (classic).
 + New domination game mode (set 'dom 1') where teams claim flags by touching them and gain points for maintaining control.
 + Can combine use_3team with teamdm or dom mode.
 - When not using maplist.ini, votes are now saved as action.ini-votes instead of maplist.ini-votes.  This fixes vote storage with 'ininame' cvar.

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -1134,6 +1134,7 @@ extern cvar_t *mapvote_next_limit; // Time left that disables map voting
 extern cvar_t *gm; // Gamemode
 extern cvar_t *gmf; // Gamemodeflags
 extern cvar_t *sv_idleremove; // Remove idlers
+extern cvar_t *g_spawn_items; // Enables item spawning in GS_WEAPONCHOOSE games
 
 #define world   (&g_edicts[0])
 
@@ -1382,7 +1383,7 @@ void ED_CallSpawn( edict_t *ent );
 char* ED_NewString(char* string);
 void G_UpdateSpectatorStatusbar( void );
 void G_UpdatePlayerStatusbar( edict_t *ent, int force );
-
+int Gamemodeflag(void);
 //
 // p_client.c
 //

--- a/source/g_main.c
+++ b/source/g_main.c
@@ -474,6 +474,7 @@ cvar_t *mapvote_next_limit;
 cvar_t *sv_idleremove;
 cvar_t *gm;
 cvar_t *gmf;
+cvar_t *g_spawn_items;
 
 void SpawnEntities (char *mapname, char *entities, char *spawnpoint);
 void ClientThink (edict_t * ent, usercmd_t * cmd);

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -427,7 +427,7 @@ void InitGame( void )
 	empty_rotate = gi.cvar( "empty_rotate", "0", 0 );
 	empty_exec = gi.cvar( "empty_exec", "", 0 );
 	llsound = gi.cvar( "llsound", "0", 0 );
-	loud_guns = gi.cvar( "loud_guns", "1", 0 );
+	loud_guns = gi.cvar( "loud_guns", "0", 0 );
 	sync_guns = gi.cvar( "sync_guns", "1", 0 );
 	silentwalk = gi.cvar( "silentwalk", "0", 0 );
 	slopefix = gi.cvar( "slopefix", "1", 0 );
@@ -555,6 +555,7 @@ void InitGame( void )
 	gm = gi.cvar("gm", "dm", CVAR_SERVERINFO);
 	gmf = gi.cvar("gmf", "0", CVAR_SERVERINFO);
 	sv_idleremove = gi.cvar("sv_idleremove", "0", 0);
+	g_spawn_items = gi.cvar("g_spawn_items", "0", CVAR_LATCH);
 
 	// items
 	InitItems();

--- a/source/p_weapon.c
+++ b/source/p_weapon.c
@@ -2227,7 +2227,7 @@ void Pistol_Fire(edict_t* ent)
 
 	//      gi.cprintf(ent, PRINT_HIGH, "Spread is %d\n", spread);
 
-	if ((ent->client->mk23_rds == 1))
+	if (ent->client->mk23_rds == 1)
 	{
 		//Hard coded for reload only.
 		ent->client->ps.gunframe = 62;

--- a/source/tng_irc.h
+++ b/source/tng_irc.h
@@ -13,9 +13,9 @@
 //
 //-----------------------------------------------------------------------------
 
-#define IRC_SERVER  	"irc.barrysworld.com"
+#define IRC_SERVER  	"irc.aq2world.com"
 #define IRC_PORT    	"6667"
-#define IRC_CHANNEL 	""
+#define IRC_CHANNEL 	"#servermsg"
 #define IRC_CHMODE  	"nt"
 #define IRC_USER    	"TNG-Bot"
 #define IRC_PASSWD  	""

--- a/source/tng_stats.c
+++ b/source/tng_stats.c
@@ -487,24 +487,3 @@ void Cmd_Statmode_f(edict_t* ent)
 	}
 	stuffcmd(ent, stuff);
 }
-
-int Gamemodeflag(void)
-// These are gamemode flags that change the rules of gamemodes.
-// For example, you can have a darkmatch matchmode 3team teamplay server
-{
-	int gamemodeflag = 0;
-	char gmfstr[16];
-
-	if (use_3teams->value) {
-		gamemodeflag += GMF_3TEAMS;
-	}
-	if (darkmatch->value) {
-		gamemodeflag += GMF_DARKMATCH;
-	}
-	if (matchmode->value) {
-		gamemodeflag += GMF_MATCHMODE;
-	}
-	sprintf(gmfstr, "%d", gamemodeflag);
-	gi.cvar_forceset("gmf", gmfstr);
-	return gamemodeflag;
-}

--- a/source/tng_stats.h
+++ b/source/tng_stats.h
@@ -6,5 +6,3 @@ void Stats_AddHit(edict_t *ent, int gun, int hitPart);
 void A_ScoreboardEndLevel (edict_t * ent, edict_t * killer);
 void Cmd_Stats_f (edict_t *targetent, char *arg);
 void Cmd_Statmode_f(edict_t *ent);
-
-int Gamemodeflag( void );


### PR DESCRIPTION
1. Added `g_spawn_items` cvar for allowing things like ammo/weapons/items to spawn in games where `GS_WEAPONCHOOSE` is enabled (like `dm_choose 1` Deathmatch) -- forced off for Matchmode play
2. Changed default `loud_guns` to `0`
3. Moved `Gamemodeflag()` to `g_spawn.c` since it game-wide and not just stats related
4. Added gm=tp when game is `use_3teams`
5. Set default irc channel to `irc.aq2world.com` (RIP Barrysworld :( )